### PR TITLE
Phase 3: Service layer — DataGeneratorService and VotingService

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,179 +1,60 @@
+import logging
 import random
 
-import psycopg2
-import requests
-import simplejson as json
-from confluent_kafka import SerializingProducer
+from config import settings
+from database.exceptions import IntegrityError
+from database.repositories import CandidateRepository, VoterRepository, create_all_tables
+from kafka_utils.producer import KafkaProducerWrapper
+from services.data_generator import DataGeneratorService
 
-BASE_URL = 'https://randomuser.me/api/?nat=gb'
-PARTIES = ["Management Party", "Savior Party", "Tech Republic Party"]
-random.seed(42)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
 
-# Kafka Topics
-voters_topic = 'voters_topic'
-candidates_topic = 'candidates_topic'
+random.seed(settings.app.random_seed)
 
 
-def create_tables(conn, cur):
-    """This function creates three tables in the PostgreSQL database if they do not already exist. 
-    - The tables are candidates, voters, and votes. Each table has a specific schema defined in the SQL commands. 
-    - The conn.commit() at the end ensures that these changes are saved to the database."""
-    cur.execute("""
-        CREATE TABLE IF NOT EXISTS candidates (
-            candidate_id VARCHAR(255) PRIMARY KEY,
-            candidate_name VARCHAR(255),
-            party_affiliation VARCHAR(255),
-            biography TEXT,
-            campaign_platform TEXT,
-            photo_url TEXT
+def seed_candidates(repo: CandidateRepository, generator: DataGeneratorService) -> None:
+    """Insert candidates if the table is empty."""
+    if repo.count() > 0:
+        logger.info("Candidates already seeded, skipping.")
+        return
+
+    for i in range(settings.app.num_candidates):
+        candidate = generator.generate_candidate(i)
+        repo.insert(candidate)
+        logger.info("Seeded candidate: %s (%s)", candidate.candidate_name, candidate.party_affiliation)
+
+
+def seed_voters(
+    repo: VoterRepository,
+    generator: DataGeneratorService,
+    producer: KafkaProducerWrapper,
+) -> None:
+    """Generate voters, persist to DB, and publish to Kafka."""
+    for i in range(settings.app.num_voters):
+        voter = generator.generate_voter()
+        try:
+            repo.insert(voter)
+        except IntegrityError:
+            logger.warning("Voter %s already exists, skipping DB insert.", voter.voter_id)
+
+        producer.produce_model(
+            topic=settings.kafka.voters_topic,
+            model=voter,
+            key_field="voter_id",
         )
-    """)
-    
-    cur.execute("""
-        CREATE TABLE IF NOT EXISTS voters (
-            voter_id VARCHAR(255) PRIMARY KEY,
-            voter_name VARCHAR(255),
-            date_of_birth VARCHAR(255),
-            gender VARCHAR(255),
-            nationality VARCHAR(255),
-            registration_number VARCHAR(255),
-            address_street VARCHAR(255),
-            address_city VARCHAR(255),
-            address_state VARCHAR(255),
-            address_country VARCHAR(255),
-            address_postcode VARCHAR(255),
-            email VARCHAR(255),
-            phone_number VARCHAR(255),
-            cell_number VARCHAR(255),
-            picture TEXT,
-            registered_age INTEGER
-        )
-    """)
-
-    cur.execute("""
-        CREATE TABLE IF NOT EXISTS votes (
-            voter_id VARCHAR(255) UNIQUE,
-            candidate_id VARCHAR(255),
-            voting_time TIMESTAMP,
-            vote int DEFAULT 1,
-            PRIMARY KEY (voter_id, candidate_id)
-        )
-    """)
-
-    conn.commit()
-
-
-def generate_voter_data():
-    """This one generates data for a voter. It makes a GET request to the randomuser.me API and formats the response into a dictionary with keys like voter_id, voter_name, date_of_birth, etc."""
-    response = requests.get(BASE_URL)
-    if response.status_code == 200:
-        user_data = response.json()['results'][0]
-        return {
-            "voter_id": user_data['login']['uuid'],
-            "voter_name": f"{user_data['name']['first']} {user_data['name']['last']}",
-            "date_of_birth": user_data['dob']['date'],
-            "gender": user_data['gender'],
-            "nationality": user_data['nat'],
-            "registration_number": user_data['login']['username'],
-            "address": {
-                "street": f"{user_data['location']['street']['number']} {user_data['location']['street']['name']}",
-                "city": user_data['location']['city'],
-                "state": user_data['location']['state'],
-                "country": user_data['location']['country'],
-                "postcode": user_data['location']['postcode']
-            },
-            "email": user_data['email'],
-            "phone_number": user_data['phone'],
-            "cell_number": user_data['cell'],
-            "picture": user_data['picture']['large'],
-            "registered_age": user_data['registered']['age']
-        }
-    else:
-        return "Error fetching data"
-
-
-def generate_candidate_data(candidate_number, total_parties):
-    """This function generates data for a candidate. It makes a GET request to the randomuser.me API and formats the response into a dictionary with keys like candidate_id, candidate_name, party_affiliation, etc. The party affiliation is chosen from a predefined list of parties, and the gender alternates based on the candidate number."""
-    response = requests.get(BASE_URL + '&gender=' + ('female' if candidate_number % 2 == 1 else 'male'))
-    if response.status_code == 200:
-        user_data = response.json()['results'][0]
-
-        return {
-            "candidate_id": user_data['login']['uuid'],
-            "candidate_name": f"{user_data['name']['first']} {user_data['name']['last']}",
-            "party_affiliation": PARTIES[candidate_number % total_parties],
-            "biography": "A brief bio of the candidate.",
-            "campaign_platform": "Key campaign promises or platform.",
-            "photo_url": user_data['picture']['large']
-        }
-    else:
-        return "Error fetching data"
-
-
-def insert_voters(conn, cur, voter):
-    """This function inserts a voter into the voters table in the PostgreSQL database. It uses the psycopg2 library to execute an INSERT SQL command. If the voter already exists in the database, it catches the psycopg2.IntegrityError and prints a message. Otherwise, it commits the changes to the database. 
-    - The voter parameter is a dictionary that contains the voter's data. 
-    - The SQL command uses placeholders (%s) for the values, which are then provided as a tuple in the second argument to cur.execute(). 
-    - The conn.commit() at the end ensures that the changes are saved to the database.""" 
-    try:
-        cur.execute("""
-                    INSERT INTO voters (voter_id, voter_name, date_of_birth, gender, nationality, registration_number, address_street, address_city, address_state, address_country, address_postcode, email, phone_number, cell_number, picture, registered_age)
-                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s,%s,%s,%s,%s,%s,%s)
-                    """,
-                    (voter["voter_id"], voter['voter_name'], voter['date_of_birth'], voter['gender'],
-                    voter['nationality'], voter['registration_number'], voter['address']['street'],
-                    voter['address']['city'], voter['address']['state'], voter['address']['country'],
-                    voter['address']['postcode'], voter['email'], voter['phone_number'],
-                    voter['cell_number'], voter['picture'], voter['registered_age'])
-                    )
-        conn.commit()
-    except psycopg2.IntegrityError:
-        print(f"Voter {voter['voter_id']} already exists in the database")
-        conn.rollback()
-            
-def delivery_report(err, msg):
-    if err is not None:
-        print(f'Message delivery failed: {err}')
-    else:
-        print(f'Message delivered to {msg.topic()} [{msg.partition()}]')
+        producer.flush()
+        logger.info("Produced voter %d: %s", i, voter.voter_id)
 
 
 if __name__ == "__main__":
-    conn = psycopg2.connect("host=localhost dbname=voting user=postgres password=postgres")
-    cur = conn.cursor()
+    create_all_tables()
 
-    producer = SerializingProducer({'bootstrap.servers': 'localhost:9092',})
-    create_tables(conn, cur)
+    generator = DataGeneratorService()
+    candidate_repo = CandidateRepository()
+    voter_repo = VoterRepository()
 
-    # get candidates from db
-    cur.execute("""
-        SELECT * FROM candidates
-    """)
-    candidates = cur.fetchall()
-    print(candidates)
+    seed_candidates(candidate_repo, generator)
 
-    if len(candidates) == 0:
-        for i in range(3):
-            candidate = generate_candidate_data(i, 3)
-            print(candidate)
-            cur.execute("""
-                        INSERT INTO candidates (candidate_id, candidate_name, party_affiliation, biography, campaign_platform, photo_url)
-                        VALUES (%s, %s, %s, %s, %s, %s)
-                    """, (
-                candidate['candidate_id'], candidate['candidate_name'], candidate['party_affiliation'], candidate['biography'],
-                candidate['campaign_platform'], candidate['photo_url']))
-            conn.commit()
-
-    for i in range(500):
-        voter_data = generate_voter_data()
-        insert_voters(conn, cur, voter_data)
-
-        producer.produce(
-            voters_topic,
-            key=voter_data["voter_id"],
-            value=json.dumps(voter_data),
-            on_delivery=delivery_report
-        )
-
-        print(f'Produced voter {i}, data: {voter_data}')
-        producer.flush() # flushes the producer to ensure all messages are delivered
+    with KafkaProducerWrapper() as producer:
+        seed_voters(voter_repo, generator, producer)

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,4 @@
+from services.data_generator import DataGeneratorService
+from services.voting_service import VotingService
+
+__all__ = ["DataGeneratorService", "VotingService"]

--- a/services/data_generator.py
+++ b/services/data_generator.py
@@ -1,0 +1,94 @@
+"""Data generation service using the randomuser.me API.
+
+Responsible solely for fetching and constructing Voter and Candidate
+objects from the external API. Extracted from main.py to follow SRP —
+data generation is now separate from database and Kafka concerns.
+"""
+
+import logging
+
+import requests
+
+from config import settings
+from models import Candidate, Voter
+from models.voter import Address
+
+logger = logging.getLogger(__name__)
+
+
+class DataGeneratorService:
+    """Generates realistic voter and candidate data from randomuser.me API.
+
+    Usage:
+        generator = DataGeneratorService()
+        voter = generator.generate_voter()
+        candidate = generator.generate_candidate(candidate_number=0)
+    """
+
+    def __init__(self, api_url: str = None):
+        self._api_url = api_url or settings.app.randomuser_api_url
+        self._parties = settings.app.parties
+
+    def generate_voter(self) -> Voter:
+        """Fetch one random user from the API and return a Voter model.
+
+        Returns:
+            Validated Voter instance
+
+        Raises:
+            RuntimeError: If the API call fails
+        """
+        response = requests.get(self._api_url)
+        if response.status_code != 200:
+            raise RuntimeError(f"Failed to fetch voter data: HTTP {response.status_code}")
+
+        user = response.json()["results"][0]
+        return Voter(
+            voter_id=user["login"]["uuid"],
+            voter_name=f"{user['name']['first']} {user['name']['last']}",
+            date_of_birth=user["dob"]["date"],
+            gender=user["gender"],
+            nationality=user["nat"],
+            registration_number=user["login"]["username"],
+            address=Address(
+                street=f"{user['location']['street']['number']} {user['location']['street']['name']}",
+                city=user["location"]["city"],
+                state=user["location"]["state"],
+                country=user["location"]["country"],
+                postcode=str(user["location"]["postcode"]),
+            ),
+            email=user["email"],
+            phone_number=user["phone"],
+            cell_number=user["cell"],
+            picture=user["picture"]["large"],
+            registered_age=user["registered"]["age"],
+        )
+
+    def generate_candidate(self, candidate_number: int) -> Candidate:
+        """Fetch one random user from the API and return a Candidate model.
+
+        Gender alternates by candidate_number to ensure diversity.
+
+        Args:
+            candidate_number: Index used to assign party and alternate gender
+
+        Returns:
+            Validated Candidate instance
+
+        Raises:
+            RuntimeError: If the API call fails
+        """
+        gender = "female" if candidate_number % 2 == 1 else "male"
+        response = requests.get(f"{self._api_url}&gender={gender}")
+        if response.status_code != 200:
+            raise RuntimeError(f"Failed to fetch candidate data: HTTP {response.status_code}")
+
+        user = response.json()["results"][0]
+        return Candidate(
+            candidate_id=user["login"]["uuid"],
+            candidate_name=f"{user['name']['first']} {user['name']['last']}",
+            party_affiliation=self._parties[candidate_number % len(self._parties)],
+            biography="A brief bio of the candidate.",
+            campaign_platform="Key campaign promises or platform.",
+            photo_url=user["picture"]["large"],
+        )

--- a/services/voting_service.py
+++ b/services/voting_service.py
@@ -1,0 +1,77 @@
+"""Voting service: consumes voter messages and produces vote records.
+
+Responsible solely for the vote processing loop: reading voters from Kafka,
+randomly assigning a candidate, persisting the vote, and publishing it back
+to Kafka. Extracted from voting.py to follow SRP.
+"""
+
+import logging
+import random
+import time
+
+from config import settings
+from database.exceptions import IntegrityError
+from database.repositories import VoteRepository
+from kafka_utils.consumer import KafkaConsumerWrapper
+from kafka_utils.producer import KafkaProducerWrapper
+from models import Candidate, Vote
+
+logger = logging.getLogger(__name__)
+
+
+class VotingService:
+    """Processes votes by consuming voters from Kafka and publishing vote records.
+
+    Usage:
+        service = VotingService(candidates, vote_repo, consumer, producer)
+        service.run()
+    """
+
+    def __init__(
+        self,
+        candidates: list[Candidate],
+        vote_repo: VoteRepository,
+        consumer: KafkaConsumerWrapper,
+        producer: KafkaProducerWrapper,
+        voting_delay: float = None,
+    ):
+        if not candidates:
+            raise ValueError("Candidate list must not be empty")
+
+        self._candidates = candidates
+        self._vote_repo = vote_repo
+        self._consumer = consumer
+        self._producer = producer
+        self._delay = voting_delay if voting_delay is not None else settings.app.voting_delay_seconds
+
+    def run(self) -> None:
+        """Start the voting loop. Runs until the consumer is stopped or interrupted."""
+        logger.info("Starting voting service...")
+        try:
+            for voter_data in self._consumer.consume():
+                self._process_vote(voter_data)
+                time.sleep(self._delay)
+        except KeyboardInterrupt:
+            logger.info("Voting service stopped.")
+
+    def _process_vote(self, voter_data: dict) -> None:
+        """Assign a random candidate to a voter, persist and publish the vote."""
+        candidate = random.choice(self._candidates)
+        vote = Vote.from_voter_and_candidate(
+            voter=voter_data,
+            candidate=candidate.model_dump(),
+        )
+
+        try:
+            self._vote_repo.insert(vote)
+            self._producer.produce_model(
+                topic=settings.kafka.votes_topic,
+                model=vote,
+                key_field="voter_id",
+            )
+            self._producer.poll(0)
+            logger.info("Voted: voter=%s -> candidate=%s", vote.voter_id, vote.candidate_id)
+        except IntegrityError:
+            logger.warning("Voter %s has already voted, skipping.", vote.voter_id)
+        except Exception:
+            logger.exception("Failed to process vote for voter=%s", vote.voter_id)

--- a/voting.py
+++ b/voting.py
@@ -1,109 +1,33 @@
+import logging
 import random
-import time
-from datetime import datetime
-import psycopg2
-import simplejson as json
-from confluent_kafka import Consumer, KafkaException, KafkaError, SerializingProducer
-from main import delivery_report
 
-conf = {
-    'bootstrap.servers': 'localhost:9092',
-}
+from config import settings
+from database.repositories import CandidateRepository, VoteRepository
+from kafka_utils.consumer import KafkaConsumerWrapper
+from kafka_utils.producer import KafkaProducerWrapper
+from services.voting_service import VotingService
 
-consumer = Consumer(conf | {
-    'group.id': 'voting-group',
-    'auto.offset.reset': 'earliest',
-    'enable.auto.commit': False
-})
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
 
-producer = SerializingProducer(conf)
-
-
-def consume_messages():
-    """This function subscribes to the 'candidates_topic' and attempts to consume messages from Kafka.
-    - It collects and appends messages to the `result` list until it has received three messages.
-    - The function returns the collected messages."""
-    result = []
-    consumer.subscribe(['candidates_topic'])
-    try:
-        while True:
-            msg = consumer.poll(timeout=1.0) # timeout in seconds, If no message is received within this time, the poll method will return None and the loop will continue to the next iteration.
-            if msg is None: 
-                continue
-            elif msg.error():
-                if msg.error().code() == KafkaError._PARTITION_EOF: # end of partition (no more messages to consume)
-                    continue
-                else:
-                    print(msg.error())
-                    break
-            else:
-                result.append(json.loads(msg.value().decode('utf-8'))) # append message to result list
-                if len(result) == 3:
-                    return result
-
-            # time.sleep(5)
-    except KafkaException as e:
-        print(e)
+random.seed(settings.app.random_seed)
 
 
 if __name__ == "__main__":
-    conn = psycopg2.connect("host=localhost dbname=voting user=postgres password=postgres")
-    cur = conn.cursor()
+    candidates = CandidateRepository().get_all()
+    if not candidates:
+        raise RuntimeError("No candidates found in database. Run main.py first.")
 
-    # candidates
-    candidates_query = cur.execute("""
-        SELECT row_to_json(t)
-        FROM (
-            SELECT * FROM candidates
-        ) t;
-    """)
-    candidates = cur.fetchall() # fetch all rows from the result set
-    candidates = [candidate[0] for candidate in candidates] # convert list of tuples to list of dictionaries
-    if len(candidates) == 0:
-        raise Exception("No candidates found in database")
-    else:
-        print(candidates)
+    logger.info("Loaded %d candidates.", len(candidates))
 
-    consumer.subscribe(['voters_topic'])
-    try:
-        while True:
-            msg = consumer.poll(timeout=1.0)
-            if msg is None:
-                continue
-            elif msg.error():
-                if msg.error().code() == KafkaError._PARTITION_EOF:
-                    continue
-                else:
-                    print(msg.error())
-                    break
-            else:
-                voter = json.loads(msg.value().decode('utf-8')) # convert message to dictionary
-                chosen_candidate = random.choice(candidates) 
-                vote = voter | chosen_candidate | {
-                    "voting_time": datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"),
-                    "vote": 1
-                } # merge dictionaries 
+    consumer = KafkaConsumerWrapper(topics=settings.kafka.voters_topic)
+    producer = KafkaProducerWrapper()
+    vote_repo = VoteRepository()
 
-                try:
-                    print("User {} is voting for candidate: {}".format(vote['voter_id'], vote['candidate_id']))
-                    cur.execute("""
-                            INSERT INTO votes (voter_id, candidate_id, voting_time)
-                            VALUES (%s, %s, %s)
-                        """, (vote['voter_id'], vote['candidate_id'], vote['voting_time']))
-
-                    conn.commit()
-
-                    producer.produce(
-                        'votes_topic',
-                        key=vote["voter_id"],
-                        value=json.dumps(vote),
-                        on_delivery=delivery_report
-                    )
-                    producer.poll(0) # wait for message to be delivered
-                except Exception as e:
-                    print("Error: {}".format(e))
-                    conn.rollback() # rollback the transaction
-                    continue
-            time.sleep(0.2)
-    except KafkaException as e:
-        print(e)
+    service = VotingService(
+        candidates=candidates,
+        vote_repo=vote_repo,
+        consumer=consumer,
+        producer=producer,
+    )
+    service.run()


### PR DESCRIPTION
## Summary

Extracts business logic from \`main.py\` and \`voting.py\` into a proper service layer, completing the wiring of Phase 1 & 2 abstractions into the application entry points.

## Changes

### New: \`services/\`
- \`data_generator.py\` — \`DataGeneratorService\` wraps the randomuser.me API, returns validated \`Voter\` / \`Candidate\` Pydantic models
- \`voting_service.py\` — \`VotingService\` encapsulates the full vote processing loop: consume voter from Kafka → assign candidate → persist via \`VoteRepository\` → publish to \`votes_topic\`

### Refactored: \`main.py\`
- Replaced raw \`psycopg2.connect()\` with \`CandidateRepository\` / \`VoterRepository\`
- Replaced hardcoded Kafka config with \`KafkaProducerWrapper\`
- Replaced inline data generation with \`DataGeneratorService\`
- No more hardcoded connection strings or magic strings

### Refactored: \`voting.py\`
- Replaced raw \`psycopg2\` / \`confluent_kafka\` usage with \`VotingService\`
- Removed \`from main import delivery_report\` coupling
- Entry point is now ~10 lines of wiring, all logic in the service

## Test plan

- [ ] \`python main.py\` seeds candidates and voters without errors
- [ ] \`python voting.py\` processes votes and publishes to \`votes_topic\`
- [ ] Duplicate voter/vote is handled gracefully (logged, not crashed)
- [ ] Stopping with Ctrl+C exits cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)