### PR TITLE
Phase 6: reliability and code quality fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Realtime Election Voting System
-===============================
+================================
 
-This repository contains the code for a realtime election voting system. The system is built using Python, Kafka, Spark Streaming, Postgres and Streamlit. The system is built using Docker Compose to easily spin up the required services in Docker containers.
+A real-time election voting system built with Python, Kafka, Spark Streaming, PostgreSQL, and Streamlit. Services are orchestrated with Docker Compose.
 
 ## System Architecture
 ![system_architecture.jpg](images%2Fsystem_architecture.jpg)
@@ -9,68 +9,126 @@ This repository contains the code for a realtime election voting system. The sys
 ## System Flow
 ![system_flow.jpg](images%2Fsystem_flow.jpg)
 
+## Project Structure
+
+```
+realtime-voting/
+├── config/                     # Centralized configuration (env-based)
+│   └── settings.py             # Settings singleton (database, kafka, spark, app)
+├── models/                     # Pydantic v2 data models
+│   ├── candidate.py            # Candidate model
+│   ├── voter.py                # Voter model
+│   └── vote.py                 # Vote model + PySpark schema
+├── services/                   # Business logic services
+│   ├── data_generator.py       # Voter/candidate generation via randomuser.me
+│   └── voting_service.py       # Vote creation and persistence
+├── kafka_utils/                # Kafka producer/consumer wrappers
+│   ├── producer.py             # KafkaProducerWrapper (confluent_kafka)
+│   ├── consumer.py             # KafkaConsumerWrapper, StreamlitKafkaConsumer
+│   ├── serializers.py          # JSON serialization utilities
+│   └── exceptions.py           # Kafka-specific exceptions
+├── database/                   # PostgreSQL data access layer
+│   ├── connection.py           # Connection management
+│   ├── repositories.py         # CRUD repositories
+│   ├── schemas.sql             # Table definitions
+│   └── exceptions.py           # Database-specific exceptions
+├── ui/                         # Streamlit UI components
+├── main.py                     # Setup: DB tables, Kafka topics, voter generation
+├── voting.py                   # Voting simulation: consume voters, produce votes
+├── spark-streaming.py          # Spark: aggregate votes and publish to Kafka
+├── streamlit-app.py            # Dashboard: real-time vote visualization
+├── .env.example                # Example environment variable configuration
+├── docker-compose.yml          # Zookeeper, Kafka, PostgreSQL containers
+├── pyproject.toml              # Poetry dependency management
+└── postgresql-42.7.2.jar       # JDBC driver for Spark ↔ PostgreSQL
+```
+
 ## System Components
-- **main.py**: This is the main Python script that creates the required tables on postgres (`candidates`, `voters` and `votes`), it also creates the Kafka topic and creates a copy of the `votes` table in the Kafka topic. It also contains the logic to consume the votes from the Kafka topic and produce data to `voters_topic` on Kafka.
-- **voting.py**: This is the Python script that contains the logic to consume the votes from the Kafka topic (`voters_topic`), generate voting data and produce data to `votes_topic` on Kafka.
-- **spark-streaming.py**: This is the Python script that contains the logic to consume the votes from the Kafka topic (`votes_topic`), enrich the data from postgres and aggregate the votes and produce data to specific topics on Kafka.
-- **streamlit-app.py**: This is the Python script that contains the logic to consume the aggregated voting data from the Kafka topic as well as postgres and display the voting data in realtime using Streamlit.
 
-## Setting up the System
-This Docker Compose file allows you to easily spin up Zookkeeper, Kafka and Postgres application in Docker containers. 
+- **`main.py`**: Initialises the system — creates PostgreSQL tables (`candidates`, `voters`, `votes`), Kafka topics, generates candidates, and publishes voter data to `voters_topic`.
+- **`voting.py`**: Consumes voter data from `voters_topic`, randomly assigns a candidate, and publishes enriched vote records to `votes_topic`.
+- **`spark-streaming.py`**: Reads votes from `votes_topic`, aggregates by candidate and by location, then streams results to `aggregated_votes_per_candidate` and `aggregated_turnout_by_location` Kafka topics.
+- **`streamlit-app.py`**: Reads aggregated data from Kafka and PostgreSQL, rendering a live dashboard with vote counts, leading candidate, and turnout breakdown.
 
-### Prerequisites
-- Python 3.9 or above installed on your machine
-- Docker Compose installed on your machine
-- Docker installed on your machine
+## Prerequisites
 
+- Python 3.11+
+- Docker and Docker Compose
+- [Poetry](https://python-poetry.org/) (recommended) or `pip`
 
-### Steps to Run
-1. Clone this repository.
-2. Navigate to the root containing the Docker Compose file.
-3. Run the following command:
+## Setting Up
+
+### 1. Start infrastructure services
 
 ```bash
 docker-compose up -d
 ```
-This command will start Zookeeper, Kafka and Postgres containers in detached mode (`-d` flag). Kafka will be accessible at `localhost:9092` and Postgres at `localhost:5432`.
 
-##### Additional Configuration
-If you need to modify Zookeeper configurations or change the exposed port, you can update the `docker-compose.yml` file according to your requirements.
+This starts Zookeeper, Kafka (`localhost:9092`), and PostgreSQL (`localhost:5432`) in detached mode.
 
-### Running the App
-1. Install the required Python packages using the following command:
+### 2. Configure environment
 
+```bash
+cp .env.example .env
+# Edit .env as needed (defaults work for local Docker setup)
+```
+
+Key variables:
+
+| Variable | Default | Description |
+|---|---|---|
+| `POSTGRES_HOST` | `localhost` | PostgreSQL host |
+| `POSTGRES_DB` | `voting` | Database name |
+| `KAFKA_BOOTSTRAP_SERVERS` | `localhost:9092` | Kafka broker address |
+| `NUM_CANDIDATES` | `3` | Number of candidates to generate |
+| `NUM_VOTERS` | `500` | Number of voters to generate |
+| `VOTING_DELAY_SECONDS` | `0.2` | Delay between votes (simulation speed) |
+| `PARTIES` | `Management Party,...` | Comma-separated party names |
+
+### 3. Install dependencies
+
+Using Poetry (recommended):
+```bash
+poetry install
+poetry shell
+```
+
+Or with pip:
 ```bash
 pip install -r requirements.txt
 ```
 
-2. Creating the required tables on Postgres and generating voter information on Kafka topic:
+## Running the App
 
+Run each component in a **separate terminal**, in order:
+
+**Terminal 1 — Initialise DB and generate data:**
 ```bash
 python main.py
 ```
 
-3. Consuming the voter information from Kafka topic, generating voting data and producing data to Kafka topic:
-
+**Terminal 2 — Run voting simulation:**
 ```bash
 python voting.py
 ```
 
-4. Consuming the voting data from Kafka topic, enriching the data from Postgres and producing data to specific topics on Kafka:
-
+**Terminal 3 — Start Spark aggregation:**
 ```bash
 python spark-streaming.py
 ```
 
-5. Running the Streamlit app:
-
+**Terminal 4 — Launch the dashboard:**
 ```bash
 streamlit run streamlit-app.py
 ```
 
+The Streamlit dashboard will be available at `http://localhost:8501`.
+
 ## Screenshots
-### Candidates and Parties information
+
+### Candidates and Parties
 ![candidates_and_party.png](images/candidates_and_party.png)
+
 ### Voters
 ![voters.png](images%2Fvoters.png)
 

--- a/kafka_utils/__init__.py
+++ b/kafka_utils/__init__.py
@@ -32,7 +32,7 @@ from kafka_utils.exceptions import (
     ProducerError,
     SerializationError,
 )
-from kafka_utils.producer import KafkaProducerWrapper, get_producer
+from kafka_utils.producer import KafkaProducerWrapper
 from kafka_utils.serializers import (
     deserialize_from_json,
     json_deserializer,
@@ -43,7 +43,6 @@ from kafka_utils.serializers import (
 __all__ = [
     # Producer
     "KafkaProducerWrapper",
-    "get_producer",
     # Consumer
     "KafkaConsumerWrapper",
     "StreamlitKafkaConsumer",

--- a/kafka_utils/consumer.py
+++ b/kafka_utils/consumer.py
@@ -198,8 +198,8 @@ class KafkaConsumerWrapper:
 class StreamlitKafkaConsumer:
     """Kafka consumer optimized for Streamlit dashboards.
 
-    Uses kafka-python library for simpler polling semantics
-    suitable for dashboard updates.
+    Uses confluent_kafka (same library as the rest of the codebase) to poll
+    all available messages from a topic from the earliest offset.
     """
 
     def __init__(self, topic: str, config: Optional[Dict[str, Any]] = None):
@@ -209,36 +209,43 @@ class StreamlitKafkaConsumer:
             topic: Topic to consume from
             config: Optional config overrides
         """
-        import simplejson as json
-        from kafka import KafkaConsumer as KPKafkaConsumer
-
         consumer_config = {
-            "bootstrap_servers": settings.kafka.bootstrap_servers,
-            "auto_offset_reset": "earliest",
-            "value_deserializer": lambda x: json.loads(x.decode("utf-8")),
+            "bootstrap.servers": settings.kafka.bootstrap_servers,
+            "group.id": f"streamlit-{topic}",
+            "auto.offset.reset": "earliest",
+            "enable.auto.commit": False,
         }
 
         if config:
             consumer_config.update(config)
 
-        self._consumer = KPKafkaConsumer(topic, **consumer_config)
+        self._consumer = Consumer(consumer_config)
+        self._consumer.subscribe([topic])
         self._topic = topic
 
     def fetch_all(self, timeout_ms: int = 1000) -> List[Dict[str, Any]]:
-        """Fetch all available messages within timeout.
+        """Fetch all currently available messages within timeout.
+
+        Polls until no new messages arrive within the timeout window.
 
         Args:
-            timeout_ms: Polling timeout in milliseconds
+            timeout_ms: Per-poll timeout in milliseconds
 
         Returns:
-            List of deserialized messages
+            List of deserialized message values
         """
-        messages = self._consumer.poll(timeout_ms=timeout_ms)
+        timeout_s = timeout_ms / 1000
         data = []
 
-        for partition_messages in messages.values():
-            for msg in partition_messages:
-                data.append(msg.value)
+        while True:
+            msg = self._consumer.poll(timeout=timeout_s)
+            if msg is None:
+                break
+            if msg.error():
+                if msg.error().code() == KafkaError._PARTITION_EOF:
+                    break
+                raise ConsumerError(f"Consumer error: {msg.error()}", topic=self._topic)
+            data.append(deserialize_from_json(msg.value()))
 
         return data
 

--- a/kafka_utils/producer.py
+++ b/kafka_utils/producer.py
@@ -169,12 +169,3 @@ class KafkaProducerWrapper:
         self.flush()
 
 
-_default_producer: Optional[KafkaProducerWrapper] = None
-
-
-def get_producer() -> KafkaProducerWrapper:
-    """Get or create the default producer instance."""
-    global _default_producer
-    if _default_producer is None:
-        _default_producer = KafkaProducerWrapper()
-    return _default_producer

--- a/models/vote.py
+++ b/models/vote.py
@@ -9,7 +9,7 @@ joining to PostgreSQL tables.
 Replaces the manual dictionary merging in voting.py:82-85 and the duplicate
 schema definition in spark-streaming.py:19-46.
 """
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 from pydantic import BaseModel, Field
 
@@ -36,7 +36,7 @@ class Vote(BaseModel):
     # Core vote data - required fields
     voter_id: str = Field(..., description="Unique voter identifier (UUID)")
     candidate_id: str = Field(..., description="Unique candidate identifier (UUID)")
-    voting_time: str = Field(..., description="Timestamp when vote was cast (YYYY-MM-DD HH:MM:SS)")
+    voting_time: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="Timestamp when vote was cast")
     vote: int = Field(default=1, ge=1, description="Vote count (always 1 per voter)")
 
     # Denormalized voter information - optional because database only stores IDs
@@ -84,15 +84,11 @@ class Vote(BaseModel):
         Converts vote to minimal tuple for PostgreSQL insertion.
 
         Follows Interface Segregation Principle by returning ONLY the fields
-        that the database needs. The votes table (main.py:54-61) only stores
-        the relationship between voter and candidate, not all the enriched data.
+        that the database needs. The votes table only stores the relationship
+        between voter and candidate, not all the enriched data.
 
-        The database schema is intentionally minimal because:
-        - Full voter/candidate data already exists in their respective tables
-        - Storing IDs only ensures referential integrity via foreign keys
-        - Enriched data flows through Kafka for real-time processing
-
-        Used by voting.py:90-92 for database insertion.
+        voting_time is formatted as a string here — the DB boundary — so the
+        rest of the application can work with proper datetime objects.
 
         Returns:
             Tuple of 3 elements: (voter_id, candidate_id, voting_time)
@@ -100,7 +96,7 @@ class Vote(BaseModel):
         return (
             self.voter_id,
             self.candidate_id,
-            self.voting_time
+            self.voting_time.strftime("%Y-%m-%d %H:%M:%S"),
         )
 
     @classmethod
@@ -108,7 +104,7 @@ class Vote(BaseModel):
         cls,
         voter: dict,
         candidate: dict,
-        voting_time: str = None
+        voting_time: datetime = None,
     ) -> 'Vote':
         """
         Factory method to create an enriched Vote from voter and candidate data.
@@ -118,35 +114,17 @@ class Vote(BaseModel):
         This follows DRY principle - when Vote model fields change, this method
         automatically adapts without code changes.
 
-        The enrichment (copying all voter and candidate fields) happens here to
-        prepare data for Kafka streaming. Spark will consume this enriched data
-        for real-time aggregation without needing database lookups.
-
-        Implementation:
-        1. Start with core vote data (voter_id, candidate_id, voting_time, vote)
-        2. Dynamically extract voter fields that exist in Vote model
-        3. Dynamically extract candidate fields that exist in Vote model
-        4. Pydantic validates the merged data and creates Vote instance
-
-        This replaces 20+ lines of hardcoded field mappings with a 3-line
-        dynamic solution that automatically stays in sync with the Vote schema.
-
         Args:
             voter: Dictionary with voter data (from Voter.model_dump())
             candidate: Dictionary with candidate data (from Candidate.model_dump())
-            voting_time: Optional timestamp string. If None, uses current UTC time.
+            voting_time: Optional datetime. If None, uses current UTC time.
 
         Returns:
             Vote instance with all fields populated (core + enriched data)
-
-        Example:
-            voter = Voter(**voter_data).model_dump()
-            candidate = Candidate(**candidate_data).model_dump()
-            vote = Vote.from_voter_and_candidate(voter, candidate)
         """
         # Default to current time if not provided
         if voting_time is None:
-            voting_time = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+            voting_time = datetime.now(timezone.utc)
 
         # Start with core vote data
         vote_data = {
@@ -177,3 +155,43 @@ class Vote(BaseModel):
         # Pydantic validates all fields and creates the Vote instance
         # Any missing required fields or type mismatches will raise ValidationError
         return cls(**vote_data)
+
+    @staticmethod
+    def spark_schema():
+        """Return the canonical PySpark StructType schema for Vote messages.
+
+        Kept here (single source of truth) so spark-streaming.py never needs
+        to duplicate or manually maintain field definitions.
+        """
+        from pyspark.sql.types import (
+            IntegerType, StringType, StructField, StructType, TimestampType,
+        )
+
+        return StructType([
+            StructField("voter_id", StringType(), True),
+            StructField("candidate_id", StringType(), True),
+            StructField("voting_time", TimestampType(), True),
+            StructField("vote", IntegerType(), True),
+            StructField("voter_name", StringType(), True),
+            StructField("date_of_birth", StringType(), True),
+            StructField("gender", StringType(), True),
+            StructField("nationality", StringType(), True),
+            StructField("registration_number", StringType(), True),
+            StructField("email", StringType(), True),
+            StructField("phone_number", StringType(), True),
+            StructField("cell_number", StringType(), True),
+            StructField("picture", StringType(), True),
+            StructField("registered_age", IntegerType(), True),
+            StructField("address", StructType([
+                StructField("street", StringType(), True),
+                StructField("city", StringType(), True),
+                StructField("state", StringType(), True),
+                StructField("country", StringType(), True),
+                StructField("postcode", StringType(), True),
+            ]), True),
+            StructField("candidate_name", StringType(), True),
+            StructField("party_affiliation", StringType(), True),
+            StructField("biography", StringType(), True),
+            StructField("campaign_platform", StringType(), True),
+            StructField("photo_url", StringType(), True),
+        ])

--- a/models/voter.py
+++ b/models/voter.py
@@ -54,7 +54,7 @@ class Voter(BaseModel):
     date_of_birth: str = Field(..., description="Date of birth in ISO format")
     gender: str = Field(..., description="Gender of the voter")
     nationality: str = Field(..., max_length=2, description="ISO country code (e.g., 'GB')")
-    registered_age: int = Field(..., ge=0, description="Age when voter registered")
+    registered_age: int = Field(..., ge=0, le=150, description="Age when voter registered")
 
     # Registration information
     registration_number: str = Field(..., description="Unique voter registration number")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ numpy = "^1.26"
 
 # Kafka messaging
 confluent-kafka = "^2.3"
-kafka-python = "^2.0"
 simplejson = "^3.19"
 
 # Database

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ importlib-resources==6.1.1
 Jinja2==3.1.2
 jsonschema==4.20.0
 jsonschema-specifications==2023.11.2
-kafka-python==2.0.2
 kiwisolver==1.4.5
 markdown-it-py==3.0.0
 MarkupSafe==2.1.3

--- a/services/data_generator.py
+++ b/services/data_generator.py
@@ -8,6 +8,7 @@ data generation is now separate from database and Kafka concerns.
 import logging
 
 import requests
+from requests.exceptions import RequestException
 
 from config import settings
 from models import Candidate, Voter
@@ -38,7 +39,10 @@ class DataGeneratorService:
         Raises:
             RuntimeError: If the API call fails
         """
-        response = requests.get(self._api_url)
+        try:
+            response = requests.get(self._api_url, timeout=10)
+        except RequestException as e:
+            raise RuntimeError(f"Failed to reach randomuser API: {e}") from e
         if response.status_code != 200:
             raise RuntimeError(f"Failed to fetch voter data: HTTP {response.status_code}")
 
@@ -79,7 +83,10 @@ class DataGeneratorService:
             RuntimeError: If the API call fails
         """
         gender = "female" if candidate_number % 2 == 1 else "male"
-        response = requests.get(f"{self._api_url}&gender={gender}")
+        try:
+            response = requests.get(f"{self._api_url}&gender={gender}", timeout=10)
+        except RequestException as e:
+            raise RuntimeError(f"Failed to reach randomuser API: {e}") from e
         if response.status_code != 200:
             raise RuntimeError(f"Failed to fetch candidate data: HTTP {response.status_code}")
 

--- a/spark-streaming.py
+++ b/spark-streaming.py
@@ -1,44 +1,12 @@
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import col, from_json
 from pyspark.sql.functions import sum as _sum
-from pyspark.sql.types import (
-    IntegerType,
-    StringType,
-    StructField,
-    StructType,
-    TimestampType,
-)
+from pyspark.sql.types import IntegerType, TimestampType
 
 from config import settings
+from models.vote import Vote
 
-VOTE_SCHEMA = StructType([
-    StructField("voter_id", StringType(), True),
-    StructField("candidate_id", StringType(), True),
-    StructField("voting_time", TimestampType(), True),
-    StructField("voter_name", StringType(), True),
-    StructField("party_affiliation", StringType(), True),
-    StructField("biography", StringType(), True),
-    StructField("campaign_platform", StringType(), True),
-    StructField("photo_url", StringType(), True),
-    StructField("candidate_name", StringType(), True),
-    StructField("date_of_birth", StringType(), True),
-    StructField("gender", StringType(), True),
-    StructField("nationality", StringType(), True),
-    StructField("registration_number", StringType(), True),
-    StructField("address", StructType([
-        StructField("street", StringType(), True),
-        StructField("city", StringType(), True),
-        StructField("state", StringType(), True),
-        StructField("country", StringType(), True),
-        StructField("postcode", StringType(), True),
-    ]), True),
-    StructField("email", StringType(), True),
-    StructField("phone_number", StringType(), True),
-    StructField("cell_number", StringType(), True),
-    StructField("picture", StringType(), True),
-    StructField("registered_age", IntegerType(), True),
-    StructField("vote", IntegerType(), True),
-])
+VOTE_SCHEMA = Vote.spark_schema()
 
 
 def build_spark_session() -> SparkSession:

--- a/streamlit-app.py
+++ b/streamlit-app.py
@@ -11,7 +11,7 @@ from ui.components.charts import plot_bar_chart, plot_donut_chart
 from ui.components.tables import paginate_table
 
 
-@st.cache_data
+@st.cache_data(ttl=30)
 def fetch_voting_stats() -> tuple[int, int]:
     """Return (voters_count, candidates_count) from the database."""
     return VoterRepository().count(), CandidateRepository().count()
@@ -35,6 +35,10 @@ def update_data() -> None:
 
     # --- Leading candidate ---
     results = fetch_kafka_data(settings.kafka.aggregated_votes_per_candidate_topic)
+    if results.empty:
+        st.info("No vote data available yet.")
+        return
+
     results = results.loc[results.groupby("candidate_id")["total_votes"].idxmax()]
     leading = results.loc[results["total_votes"].idxmax()]
 
@@ -42,7 +46,10 @@ def update_data() -> None:
     st.header("Leading Candidate")
     col1, col2 = st.columns(2)
     with col1:
-        st.image(leading["photo_url"], width=200)
+        try:
+            st.image(leading["photo_url"], width=200)
+        except Exception:
+            st.caption("Photo unavailable")
     with col2:
         st.header(leading["candidate_name"])
         st.subheader(leading["party_affiliation"])


### PR DESCRIPTION
## Summary
- **Models**: `voting_time` is now a proper `datetime` (formatted to string only at the DB boundary); `registered_age` bounded to `le=150`; `Vote.spark_schema()` added as the single source of truth for the PySpark schema
- **Kafka**: removed unused `get_producer()` global singleton; `StreamlitKafkaConsumer` rewritten to use `confluent_kafka` (eliminates the `kafka-python` dependency)
- **Services**: `requests.get()` calls now have a 10s timeout and `RequestException` handling to prevent hangs/silent crashes
- **Spark**: `VOTE_SCHEMA` derived from `Vote.spark_schema()` — no more duplicated field list
- **Streamlit**: `fetch_voting_stats()` cache TTL set to 30s; empty-dataframe guard added; photo URL wrapped in try/except with fallback

## Test plan
- [ ] Run `main.py` — seeding should complete without network timeout crashes
- [ ] Run `voting.py` — votes should flow through with correct `datetime` serialization
- [ ] Run `spark-streaming.py` — schema should match Kafka messages without field mismatches
- [ ] Open Streamlit dashboard — stats should refresh every 30s; empty state shows info message instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)